### PR TITLE
Update scn_train.py to fix column indexing

### DIFF
--- a/pySingleCellNet/scn_train.py
+++ b/pySingleCellNet/scn_train.py
@@ -91,7 +91,7 @@ def scn_classify(adata, cgenes, xpairs, rf_tsp, nrand = 0 ):
 def add_classRes(adata: AnnData, adClassRes, copy=False) -> AnnData:
     cNames = adClassRes.var_names
     for cname in cNames:
-        adata.obs[cname] = adClassRes[:,cname].X
+        adata.obs[cname] = adClassRes[:,cname].X.toarray()
     # adata.obs['category'] = adClassRes.obs['category']
     adata.obs['SCN_class'] = adClassRes.obs['SCN_class']
     return adata if copy else None


### PR DESCRIPTION
Some CSCB students ran into issues with this line of this function yielding ValueError: Data must be 1-dimensional. This fixes that.